### PR TITLE
fix: Remove database password from logs

### DIFF
--- a/post-service/cmd/main.go
+++ b/post-service/cmd/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	log.Println("Starting application...")
 	conf := config.NewConfig()
-	log.Printf("Configuration loaded. DNS: %s\n", conf.Dns)
+	log.Println("Configuration loaded successfully")
 
 	r := gin.Default()
 	log.Println("Gin router initialized.")


### PR DESCRIPTION
## 🔒 Security Fix: Remove Password Leak

This PR fixes a **critical security vulnerability** where database credentials were being logged to stdout.

### 🐞 Problem

Line 18 in `cmd/main.go` was logging the full DNS connection string:
```go
log.Printf("Configuration loaded. DNS: %s\n", conf.Dns)
// Output: Configuration loaded. DNS: host=post-db user=postuser password=postpass...
```

This caused the database password to appear in:
- Application stdout
- Docker container logs
- Centralized logging systems (ELK, CloudWatch, etc.)
- Monitoring dashboards

### ✅ Solution

Replaced the detailed log with a generic success message:
```go
log.Println("Configuration loaded successfully")
```

### 📝 Changes

- **Modified:** `post-service/cmd/main.go` (1 line changed)
- **Impact:** No functional changes, only logging behavior

### 🧹 Testing

To verify the fix:
```bash
# Build and run
cd post-service
go run cmd/main.go

# Check logs - password should NOT appear
# Before: Configuration loaded. DNS: host=post-db user=postuser password=postpass...
# After:  Configuration loaded successfully
```

### 🔗 Related

Closes #45

### 📊 Security Impact

- **Severity:** Critical
- **CVSS:** Sensitive data exposure
- **Affected versions:** All previous versions
- **Recommendation:** Deploy immediately

---

**Reviewer checklist:**
- [ ] Password no longer appears in logs
- [ ] Application still starts correctly
- [ ] No other credentials logged elsewhere